### PR TITLE
fix global environment pollution and unlet the variables

### DIFF
--- a/autoload/unite/sources/quicklearn.vim
+++ b/autoload/unite/sources/quicklearn.vim
@@ -76,6 +76,7 @@ for s:k in keys(s:quicklearn)
   endfor
   unlet! s:v
 endfor
+unlet! s:k
 
 " build quickrun command
 for s:k in keys(s:quicklearn)
@@ -88,6 +89,7 @@ for s:k in keys(s:quicklearn)
         \ string(get(s:v, 'cmdopt', '')))
   unlet! s:v
 endfor
+unlet! s:k
 lockvar s:quicklearn
 
 function! unite#sources#quicklearn#define()

--- a/autoload/unite/sources/quicklearn.vim
+++ b/autoload/unite/sources/quicklearn.vim
@@ -65,26 +65,28 @@ let s:quicklearn['ruby/intermediate'] = {
       \ 'cmdopt': '--dump=insns'}
 
 " inheritance
-for k in keys(s:quicklearn)
-  let v = s:quicklearn[k]
+for s:k in keys(s:quicklearn)
+  let s:v = s:quicklearn[s:k]
   for item in ['command', 'exec', 'cmdopt', 'tempfile', 'eval_template']
-    let ofParent = get(g:quickrun#default_config[v.meta.parent], item)
+    let ofParent = get(g:quickrun#default_config[s:v.meta.parent], item)
     if type(ofParent) != type(0) || ofParent != 0
-      let s:quicklearn[k][item] = get(v, item, ofParent)
+      let s:quicklearn[s:k][item] = get(s:v, item, ofParent)
     endif
     unlet ofParent
   endfor
+  unlet! s:k s:v
 endfor
 
 " build quickrun command
-for k in keys(s:quicklearn)
-  let v = s:quicklearn[k]
-  let s:quicklearn[k].quickrun_command = printf(
+for s:k in keys(s:quicklearn)
+  let s:v = s:quicklearn[s:k]
+  let s:quicklearn[s:k].quickrun_command = printf(
         \ 'QuickRun %s %s %s -cmdopt %s',
-        \ v.meta.parent == '_' ? '' : '-type ' . v.meta.parent,
-        \ get(v, 'command') ? '-command ' . string(v.command) : '',
-        \ join(s:fmap(get(v, 'exec', []), '"-exec " . string(v:val)'), ' '),
-        \ string(get(v, 'cmdopt', '')))
+        \ s:v.meta.parent == '_' ? '' : '-type ' . s:v.meta.parent,
+        \ get(s:v, 'command') ? '-command ' . string(s:v.command) : '',
+        \ join(s:fmap(get(s:v, 'exec', []), '"-exec " . string(v:val)'), ' '),
+        \ string(get(s:v, 'cmdopt', '')))
+  unlet! s:k s:v
 endfor
 lockvar s:quicklearn
 

--- a/autoload/unite/sources/quicklearn.vim
+++ b/autoload/unite/sources/quicklearn.vim
@@ -67,14 +67,14 @@ let s:quicklearn['ruby/intermediate'] = {
 " inheritance
 for s:k in keys(s:quicklearn)
   let s:v = s:quicklearn[s:k]
-  for item in ['command', 'exec', 'cmdopt', 'tempfile', 'eval_template']
-    let ofParent = get(g:quickrun#default_config[s:v.meta.parent], item)
+  for s:item in ['command', 'exec', 'cmdopt', 'tempfile', 'eval_template']
+    let ofParent = get(g:quickrun#default_config[s:v.meta.parent], s:item)
     if type(ofParent) != type(0) || ofParent != 0
-      let s:quicklearn[s:k][item] = get(s:v, item, ofParent)
+      let s:quicklearn[s:k][s:item] = get(s:v, s:item, ofParent)
     endif
     unlet ofParent
   endfor
-  unlet! s:v
+  unlet! s:v s:item
 endfor
 unlet! s:k
 

--- a/autoload/unite/sources/quicklearn.vim
+++ b/autoload/unite/sources/quicklearn.vim
@@ -74,7 +74,7 @@ for s:k in keys(s:quicklearn)
     endif
     unlet ofParent
   endfor
-  unlet! s:k s:v
+  unlet! s:v
 endfor
 
 " build quickrun command
@@ -86,7 +86,7 @@ for s:k in keys(s:quicklearn)
         \ get(s:v, 'command') ? '-command ' . string(s:v.command) : '',
         \ join(s:fmap(get(s:v, 'exec', []), '"-exec " . string(v:val)'), ' '),
         \ string(get(s:v, 'cmdopt', '')))
-  unlet! s:k s:v
+  unlet! s:v
 endfor
 lockvar s:quicklearn
 


### PR DESCRIPTION
This pull request fixes the leakage of variables to the global environment; the variables `k` and `v` are global variables, which should be script local variables. Also, use `unlet!` just in case the type of elements changes.
